### PR TITLE
Clean up warnings in benchmarks

### DIFF
--- a/PIMbench/Makefile.common
+++ b/PIMbench/Makefile.common
@@ -24,7 +24,7 @@ ifeq ($(MAKECMDGOALS),debug)
 	CXXFLAGS += -g -DDEBUG
 endif
 ifeq ($(MAKECMDGOALS),perf)
-	CXXFLAGS += -Ofast
+	CXXFLAGS += -Ofast -Wno-unused-variable
 endif
 ifeq ($(MAKECMDGOALS),dramsim3_integ)
 	CXXFLAGS += -Ofast -DDRAMSIM3_INTEG

--- a/PIMbench/cpp-aes/aes.cpp
+++ b/PIMbench/cpp-aes/aes.cpp
@@ -107,10 +107,10 @@ const uint8_t sboxinv[256] = {
 typedef struct Params
 {
     uint64_t inputSize;
-    char *keyFile;
-    char *inputFile;
-    char *cipherFile;
-    char *outputFile;
+    const char *keyFile;
+    const char *inputFile;
+    const char *cipherFile;
+    const char *outputFile;
     bool shouldVerify;
 } Params;
  

--- a/PIMbench/cpp-brightness/brightness.cpp
+++ b/PIMbench/cpp-brightness/brightness.cpp
@@ -131,7 +131,7 @@ int main(int argc, char *argv[])
   int imgDataOffsetPosition;
 
   // Start data parsing
-  if (!fn.substr(fn.find_last_of(".") + 1).compare("bmp") == 0)
+  if (fn.substr(fn.find_last_of(".") + 1) != "bmp")
   {
     // TODO: reading in other types of input files
     std::cout << "Need work reading in other file types" << std::endl;
@@ -166,7 +166,7 @@ int main(int argc, char *argv[])
   }
   // End data parsing
 
-  printf("This file has %ld bytes of image data with a brightness coefficient of %d\n", imgDataBytes, params.brightnessCoefficient);
+  printf("This file has %llu bytes of image data with a brightness coefficient of %d\n", imgDataBytes, params.brightnessCoefficient);
 
   if (!createDevice(params.configFile))
   {

--- a/PIMbench/cpp-brightness/brightness.cpp
+++ b/PIMbench/cpp-brightness/brightness.cpp
@@ -131,7 +131,7 @@ int main(int argc, char *argv[])
   int imgDataOffsetPosition;
 
   // Start data parsing
-  if (fn.substr(fn.find_last_of(".") + 1) != "bmp")
+  if (fn.substr(fn.find_last_of(".")) != ".bmp")
   {
     // TODO: reading in other types of input files
     std::cout << "Need work reading in other file types" << std::endl;

--- a/PIMbench/cpp-histogram/hist.cpp
+++ b/PIMbench/cpp-histogram/hist.cpp
@@ -143,7 +143,7 @@ int main(int argc, char *argv[])
   unsigned short* dataPos;
 
   // Start data parsing
-  if (fn.substr(fn.find_last_of(".") + 1) != "bmp")
+  if (fn.substr(fn.find_last_of(".")) != ".bmp")
   {
     // TODO: reading in other types of input files
     std::cout << "Need work reading in other file types" << std::endl;

--- a/PIMbench/cpp-histogram/hist.cpp
+++ b/PIMbench/cpp-histogram/hist.cpp
@@ -143,7 +143,7 @@ int main(int argc, char *argv[])
   unsigned short* dataPos;
 
   // Start data parsing
-  if (!fn.substr(fn.find_last_of(".") + 1).compare("bmp") == 0)
+  if (fn.substr(fn.find_last_of(".") + 1) != "bmp")
   {
     // TODO: reading in other types of input files
     std::cout << "Need work reading in other file types" << std::endl;
@@ -178,7 +178,7 @@ int main(int argc, char *argv[])
   }
   // End data parsing
 
-  printf("This file has %ld bytes of image data, %ld pixels\n", imgDataBytes, imgDataBytes / NUMCHANNELS);
+  printf("This file has %llu bytes of image data, %llu pixels\n", imgDataBytes, imgDataBytes / NUMCHANNELS);
 
   if (!createDevice(params.configFile))
   {

--- a/PIMbench/cpp-triangle-count/PIM/tc.cpp
+++ b/PIMbench/cpp-triangle-count/PIM/tc.cpp
@@ -33,8 +33,8 @@ using namespace std;
 // Params ---------------------------------------------------------------------
 typedef struct Params
 {
-  char *configFile;
-  char *inputFile;
+  const char *configFile;
+  const char *inputFile;
   bool shouldVerify;
 } Params;
 

--- a/PIMbench/util.h
+++ b/PIMbench/util.h
@@ -92,7 +92,7 @@ void flatten3DMat(std::vector<std::vector<std::vector<int>>>& inputMatrix, std::
   }
 }
 
-bool createDevice(char *configFile)
+bool createDevice(const char *configFile)
 {
   if (configFile == nullptr)
   {

--- a/misc-bench/Makefile.common
+++ b/misc-bench/Makefile.common
@@ -24,7 +24,7 @@ ifeq ($(MAKECMDGOALS),debug)
 	CXXFLAGS += -g -DDEBUG
 endif
 ifeq ($(MAKECMDGOALS),perf)
-	CXXFLAGS += -Ofast
+	CXXFLAGS += -Ofast -Wno-unused-variable
 endif
 ifeq ($(MAKECMDGOALS),dramsim3_integ)
 	CXXFLAGS += -Ofast -DDRAMSIM3_INTEG

--- a/tests/Makefile.common
+++ b/tests/Makefile.common
@@ -24,7 +24,7 @@ ifeq ($(MAKECMDGOALS),debug)
 	CXXFLAGS += -g -DDEBUG
 endif
 ifeq ($(MAKECMDGOALS),perf)
-	CXXFLAGS += -Ofast
+	CXXFLAGS += -Ofast -Wno-unused-variable
 endif
 ifeq ($(MAKECMDGOALS),dramsim3_integ)
 	CXXFLAGS += -Ofast -DDRAMSIM3_INTEG


### PR DESCRIPTION
- Do not warn for unused variables for perf build
- Use const char * for file names
- Use %llu to print unsigned long long
- C++ style string comparison