### PR TITLE
Support get ith element location in a region for mixed data types.

### DIFF
--- a/libpimeval/src/pimCmd.cpp
+++ b/libpimeval/src/pimCmd.cpp
@@ -500,8 +500,8 @@ pimCmdFunc1::computeRegion(unsigned index)
   unsigned numElementsInRegion = srcRegion.getNumElemInRegion();
   for (unsigned j = 0; j < numElementsInRegion; ++j) {
     if (dataType == PIM_INT8 || dataType == PIM_INT16 || dataType == PIM_INT32 || dataType == PIM_INT64 || dataType == PIM_UINT8 || dataType == PIM_UINT16 || dataType == PIM_UINT32 || dataType == PIM_UINT64) {
-      auto locSrc = locateNthElement(srcRegion, isVLayout, j, bitsPerElementSrc);
-      auto locDest = locateNthElement(destRegion, isVLayout, j, bitsPerElementDest);
+      auto locSrc = srcRegion.locateIthElemInRegion(j);
+      auto locDest = destRegion.locateIthElemInRegion(j);
       auto operandBits = getBits(core, isVLayout, locSrc.first, locSrc.second, bitsPerElementSrc);
       bool isSigned = (dataType == PIM_INT8 || dataType == PIM_INT16 || dataType == PIM_INT32 || dataType == PIM_INT64);
       if (isSigned) {
@@ -597,9 +597,9 @@ pimCmdFunc2::computeRegion(unsigned index)
   // perform the computation
   unsigned numElementsInRegion = src1Region.getNumElemInRegion();
   for (unsigned j = 0; j < numElementsInRegion; ++j) {
-    auto locSrc1 = locateNthElement(src1Region, isVLayout, j, bitsPerElementSrc1);
-    auto locSrc2 = locateNthElement(src2Region, isVLayout, j, bitsPerElementSrc2);
-    auto locDest = locateNthElement(destRegion, isVLayout, j, bitsPerElementdest);
+    auto locSrc1 = src1Region.locateIthElemInRegion(j);
+    auto locSrc2 = src2Region.locateIthElemInRegion(j);
+    auto locDest = destRegion.locateIthElemInRegion(j);
 
     if (dataType == PIM_INT8 || dataType == PIM_INT16 || dataType == PIM_INT32 || dataType == PIM_INT64 || dataType == PIM_UINT8 || dataType == PIM_UINT16 || dataType == PIM_UINT32 || dataType == PIM_UINT64) {
       auto operandBits1 = getBits(core, isVLayout, locSrc1.first, locSrc1.second, bitsPerElementSrc1);
@@ -767,7 +767,7 @@ pimCmdRedSum<T>::computeRegion(unsigned index)
   uint64_t currIdx = srcRegion.getElemIdxBegin();
   for (unsigned j = 0; j < numElementsInRegion && currIdx < m_idxEnd; ++j) {
     if (currIdx >= m_idxBegin) {
-      auto locSrc = locateNthElement(srcRegion, isVLayout, j, bitsPerElement);
+      auto locSrc = srcRegion.locateIthElemInRegion(j);
       auto operandBits = getBits(core, isVLayout, locSrc.first, locSrc.second, bitsPerElement);
       T operand = getOperand(operandBits, objSrc.getDataType());
       m_regionSum[index] += operand;
@@ -862,7 +862,7 @@ pimCmdBroadcast<T>::computeRegion(unsigned index)
 
   uint64_t val = *reinterpret_cast<uint64_t *>(&m_val);
   for (unsigned j = 0; j < numElementsInRegion; ++j) {
-    auto locDest = locateNthElement(destRegion, isVLayout, j, bitsPerElement);
+    auto locDest = destRegion.locateIthElemInRegion(j);
     setBits(core, isVLayout, locDest.first, locDest.second, val, bitsPerElement);
   }
   return true;
@@ -908,7 +908,7 @@ pimCmdRotate::execute()
       const pimRegion &srcRegion = objSrc.getRegions()[i];
       unsigned coreId = srcRegion.getCoreId();
       pimCore &core = m_device->getCore(coreId);
-      auto locSrc = locateNthElement(srcRegion, isVLayout, 0, bitsPerElement);
+      auto locSrc = srcRegion.locateIthElemInRegion(0);
       uint64_t val = 0;
       if (i == 0 && m_cmdType == PimCmdEnum::ROTATE_ELEM_R) {
         val = m_regionBoundary[numRegions - 1];
@@ -923,9 +923,9 @@ pimCmdRotate::execute()
       unsigned coreId = srcRegion.getCoreId();
       pimCore &core = m_device->getCore(coreId);
       unsigned numElementsInRegion = srcRegion.getNumElemInRegion();
-      auto locSrc = locateNthElement(srcRegion, isVLayout, numElementsInRegion - 1, bitsPerElement);
+      auto locSrc = srcRegion.locateIthElemInRegion(numElementsInRegion - 1);
       uint64_t val = 0;
-      if (i == numRegions - 1 && m_cmdType == PimCmdEnum::ROTATE_ELEM_R) {
+      if (i == numRegions - 1 && m_cmdType == PimCmdEnum::ROTATE_ELEM_L) {
         val = m_regionBoundary[0];
       } else if (i < numRegions - 1) {
         val = m_regionBoundary[i + 1];
@@ -967,7 +967,7 @@ pimCmdRotate::computeRegion(unsigned index)
   unsigned numElementsInRegion = srcRegion.getNumElemInRegion();
   std::vector<uint64_t> regionVector(numElementsInRegion);
   for (unsigned j = 0; j < numElementsInRegion; ++j) {
-    auto locSrc = locateNthElement(srcRegion, isVLayout, j, bitsPerElement);
+    auto locSrc = srcRegion.locateIthElemInRegion(j);
     regionVector[j] = getBits(core, isVLayout, locSrc.first, locSrc.second, bitsPerElement);
   }
 
@@ -994,7 +994,7 @@ pimCmdRotate::computeRegion(unsigned index)
 
   // write back values
   for (unsigned j = 0; j < numElementsInRegion; ++j) {
-    auto locSrc = locateNthElement(srcRegion, isVLayout, j, bitsPerElement);
+    auto locSrc = srcRegion.locateIthElemInRegion(j);
     setBits(core, isVLayout, locSrc.first, locSrc.second, regionVector[j], bitsPerElement);
   }
   return true;

--- a/libpimeval/src/pimCmd.h
+++ b/libpimeval/src/pimCmd.h
@@ -124,30 +124,6 @@ protected:
   virtual bool updateStats() const { return false; }
   bool computeAllRegions(unsigned numRegions);
 
-  //! @brief  Utility: Locate nth element in region
-  inline std::pair<unsigned, unsigned> locateNthElement(const pimRegion& region, bool isVLayout, unsigned nth, unsigned numBits) const
-  {
-    unsigned colIdx = region.getColIdx();
-    unsigned numAllocCols = region.getNumAllocCols();
-    unsigned rowIdx = region.getRowIdx();
-    unsigned numAllocRows = region.getNumAllocRows();
-    unsigned r = 0;
-    unsigned c = 0;
-
-    // TODO: Decide if numBits is always going to be power of 2. If so, replace '/' & '%' with shift and bit-wise operation.
-    if (isVLayout) {
-      assert(numAllocRows % numBits == 0);
-      r = rowIdx + (nth / numAllocCols) * numBits;
-      c = colIdx + nth % numAllocCols;
-    } else {
-      assert(numAllocCols % numBits == 0);
-      unsigned numBitsPerRow = numAllocCols / numBits;
-      r = rowIdx + nth / numBitsPerRow;
-      c = colIdx + (nth % numBitsPerRow) * numBits;
-    }
-    return std::make_pair(r, c);
-  }
-
   //! @brief  Utility: Get a value from a region
   inline uint64_t getBits(const pimCore& core, bool isVLayout, unsigned rowLoc, unsigned colLoc, unsigned numBits) const
   {

--- a/libpimeval/src/pimResMgr.cpp
+++ b/libpimeval/src/pimResMgr.cpp
@@ -68,6 +68,7 @@ pimObjInfo::finalize()
 
   const pimRegion& region = m_regions[0];
   m_maxElementsPerRegion = (uint64_t)region.getNumAllocRows() * region.getNumAllocCols() / m_bitsPerElement;
+  m_numColsPerElem = region.getNumColsPerElem();
 }
 
 //! @brief  Get all regions on a specific PIM core for current PIM object
@@ -125,6 +126,7 @@ pimResMgr::pimAlloc(PimAllocEnum allocType, uint64_t numElements, unsigned bitsP
   unsigned numColsToAllocLast = 0;
   uint64_t numElemPerRegion = 0;
   uint64_t numElemPerRegionLast = 0;
+  unsigned numColsPerElem = 0;
   if (allocType == PIM_ALLOC_V || allocType == PIM_ALLOC_V1) {
     // allocate one region per core, with vertical layout
     numRowsToAlloc = bitsPerElement;
@@ -135,6 +137,7 @@ pimResMgr::pimAlloc(PimAllocEnum allocType, uint64_t numElements, unsigned bitsP
     }
     numElemPerRegion = numCols;
     numElemPerRegionLast = numColsToAllocLast;
+    numColsPerElem = 1;
   } else if (allocType == PIM_ALLOC_H || allocType == PIM_ALLOC_H1) {
     // allocate one region per core, with horizontal layout
     numRowsToAlloc = 1;
@@ -145,6 +148,7 @@ pimResMgr::pimAlloc(PimAllocEnum allocType, uint64_t numElements, unsigned bitsP
     }
     numElemPerRegion = numCols / bitsPerElement;
     numElemPerRegionLast = numColsToAllocLast / bitsPerElement;
+    numColsPerElem = bitsPerElement;
   } else {
     std::printf("PIM-Error: Unsupported PIM allocation type %d\n", static_cast<int>(allocType));
     return -1;
@@ -181,6 +185,7 @@ pimResMgr::pimAlloc(PimAllocEnum allocType, uint64_t numElements, unsigned bitsP
       newRegion.setElemIdxBegin(elemIdx);
       elemIdx += numElemInRegion;
       newRegion.setElemIdxEnd(elemIdx); // exclusive
+      newRegion.setNumColsPerElem(numColsPerElem);
       newObj.addRegion(newRegion);
 
       // add to core usage map
@@ -268,6 +273,7 @@ pimResMgr::pimAllocAssociated(unsigned bitsPerElement, PimObjId assocId, PimData
     }
     newRegion.setElemIdxBegin(region.getElemIdxBegin());
     newRegion.setElemIdxEnd(region.getElemIdxEnd()); // exclusive
+    newRegion.setNumColsPerElem(region.getNumColsPerElem());
     newObj.addRegion(newRegion);
 
     // add to core usage map

--- a/libpimeval/src/pimResMgr.h
+++ b/libpimeval/src/pimResMgr.h
@@ -35,6 +35,7 @@ public:
   void setElemIdxBegin(uint64_t idx) { m_elemIdxBegin = idx; }
   void setElemIdxEnd(uint64_t idx) { m_elemIdxEnd = idx; }
   void setIsValid(bool val) { m_isValid = val; }
+  void setNumColsPerElem(unsigned val) { m_numColsPerElem = val; }
 
   PimCoreId getCoreId() const { return m_coreId; }
   unsigned getRowIdx() const { return m_rowIdx; }
@@ -44,6 +45,14 @@ public:
   uint64_t getElemIdxBegin() const { return m_elemIdxBegin; }
   uint64_t getElemIdxEnd() const { return m_elemIdxEnd; }
   uint64_t getNumElemInRegion() const { return m_elemIdxEnd - m_elemIdxBegin; }
+  unsigned getNumColsPerElem() const { return m_numColsPerElem; }
+
+  std::pair<unsigned, unsigned> locateIthElemInRegion(unsigned i) const {
+    assert(i < getNumElemInRegion());
+    unsigned rowIdx = m_rowIdx; // only one row of elements per region
+    unsigned colIdx = m_colIdx + i * m_numColsPerElem;
+    return std::make_pair(rowIdx, colIdx);
+  }
 
   bool isValid() const { return m_isValid && m_coreId >= 0 && m_numAllocRows > 0 && m_numAllocCols > 0; }
 
@@ -57,6 +66,7 @@ private:
   unsigned m_numAllocCols = 0;  // number of cols of this region
   uint64_t m_elemIdxBegin = 0;  // begin element index in this region
   uint64_t m_elemIdxEnd = 0;    // end element index in this region
+  unsigned m_numColsPerElem = 0;  // number of cols per element
   bool m_isValid = false;
 };
 
@@ -84,6 +94,7 @@ public:
   void setAssocObjId(PimObjId assocObjId) { m_assocObjId = assocObjId; }
   void setRefObjId(PimObjId refObjId) { m_refObjId = refObjId; }
   void setIsDualContactRef(bool val) { m_isDualContactRef = val; }
+  void setNumColsPerElem(unsigned val) { m_numColsPerElem = val; }
   void finalize();
 
   PimObjId getObjId() const { return m_objId; }
@@ -103,6 +114,7 @@ public:
   unsigned getMaxNumRegionsPerCore() const { return m_maxNumRegionsPerCore; }
   unsigned getNumCoresUsed() const { return m_numCoresUsed; }
   unsigned getMaxElementsPerRegion() const { return m_maxElementsPerRegion; }
+  unsigned getNumColsPerElem() const { return m_numColsPerElem; }
 
   std::string getDataTypeName() const;
   void print() const;
@@ -119,6 +131,7 @@ private:
   unsigned m_maxNumRegionsPerCore = 0;
   unsigned m_numCoresUsed = 0;
   unsigned m_maxElementsPerRegion = 0;
+  unsigned m_numColsPerElem = 0; // number of cols per element
   bool m_isDualContactRef = false;
 };
 


### PR DESCRIPTION
2nd batch of code for supporting mixed data types and element padding:
- Support querying ith element location directly from a region instead of in pimCmd
- Fixed a bug in pimRotateElementsLeft. No impact on benchmarks since it is not used.

No impact on existing behavior. Can be merged before other PRs. 
Related to Issue #16.