### PR TITLE
Perf energy model of reduction sum for bit-serial PIM, and various fixes

### DIFF
--- a/PIMbench/cpp-aes/PIM/Makefile
+++ b/PIMbench/cpp-aes/PIM/Makefile
@@ -18,7 +18,7 @@ endif
 debug perf dramsim3_integ: $(EXEC)
 
 $(EXEC): $(SRCS) $(DEPS)
-	$(CXX) $(SRCS) $(DEPS) $(CXXFLAGS) -o $@
+	$(CXX) $(SRCS) $(CXXFLAGS) -o $@
 
 clean:
 	rm -rf $(EXEC) *.dSYM

--- a/libpimeval/src/pimDevice.cpp
+++ b/libpimeval/src/pimDevice.cpp
@@ -20,7 +20,7 @@
 #include <cctype>
 #include <locale>
 #include <stdexcept>
-#include <filesystem> 
+#include <filesystem>
 
 //! @brief  pimDevice ctor
 pimDevice::pimDevice()
@@ -140,7 +140,7 @@ pimDevice::isHybridLayoutDevice() const
   return false;
 }
 
-//! @brief  Init pim device, with input arguments 
+//! @brief  Init pim device, with input arguments
 bool
 pimDevice::init(PimDeviceEnum deviceType, unsigned numRanks, unsigned numBankPerRank, unsigned numSubarrayPerBank, unsigned numRows, unsigned numCols)
 {
@@ -234,11 +234,17 @@ pimDevice::init(PimDeviceEnum deviceType, const char* configFileName)
 
   std::string fileContent;
   success = pimUtils::readFileContent(configFileName, fileContent);
-  assert(success);
-  
+  if (!success) {
+    std::printf("PIM-Error: Failed to read config file %s\n", configFileName);
+    return false;
+  }
+
   // input params
   success = parseConfigFromFile(fileContent, numRanks, numBankPerRank, numSubarrayPerBank, numRows, numCols);
-  assert(success);
+  if (!success) {
+    std::printf("PIM-Error: Failed to parse config file %s\n", configFileName);
+    return false;
+  }
 
   std::printf("PIM-Info: Current Device = %s, Simulation Target = %s\n",
               pimUtils::pimDeviceEnumToStr(m_deviceType).c_str(),
@@ -290,8 +296,8 @@ pimDevice::init(PimDeviceEnum deviceType, const char* configFileName)
 }
 
 //! @brief Initilize the device config parameters by parsing the config file
-bool 
-pimDevice::parseConfigFromFile(const std::string& config, unsigned& numRanks, unsigned& numBankPerRank, unsigned& numSubarrayPerBank, unsigned& numRows, unsigned& numCols) 
+bool
+pimDevice::parseConfigFromFile(const std::string& config, unsigned& numRanks, unsigned& numBankPerRank, unsigned& numSubarrayPerBank, unsigned& numRows, unsigned& numCols)
 {
   std::istringstream configStream(config);
   std::string line;

--- a/libpimeval/src/pimDevice.h
+++ b/libpimeval/src/pimDevice.h
@@ -15,7 +15,7 @@
 #endif
 #include <memory>
 #include <filesystem>
-#include <string> 
+#include <string>
 
 class pimResMgr;
 

--- a/libpimeval/src/pimPerfEnergyModels.cpp
+++ b/libpimeval/src/pimPerfEnergyModels.cpp
@@ -4,7 +4,7 @@
 // This file is licensed under the MIT License.
 // See the LICENSE file in the root of this repository for more details.
 
-#include "pimParamsPerf.h"
+#include "pimPerfEnergyModels.h"
 #include "pimSim.h"
 #include "pimCmd.h"
 #include "pimPerfEnergyTables.h"

--- a/libpimeval/src/pimPerfEnergyModels.cpp
+++ b/libpimeval/src/pimPerfEnergyModels.cpp
@@ -457,13 +457,17 @@ pimParamsPerf::getPerfEnergyForRedSum(PimCmdEnum cmdType, const pimObjInfo& obj,
   case PIM_DEVICE_BITSIMD_V_AP:
   {
     if (dataType == PIM_INT8 || dataType == PIM_INT16 || dataType == PIM_INT64 || dataType == PIM_INT32 || dataType == PIM_UINT8 || dataType == PIM_UINT16 || dataType == PIM_UINT32 || dataType == PIM_UINT64) {
-      // Assume pop count reduction circut in tR runtime
-      msRuntime = ((m_tR + m_tR) * bitsPerElement);
-      msRuntime *= numPass;
-      mjEnergy = m_eAP * bitsPerElement * numPass;
+      // Assume row-wide popcount capability for integer reduction, with a 64-bit popcount logic unit per PIM core
+      // For a single row, popcount is calculated per 64-bit chunks, and result is shifted then added to an 64-bit accumulator register
+      // If there are multiple regions per core, the multi-region reduction sum is stored in the accumulator
+      double mjEnergyPerPcl = m_pclNsDelay * m_pclUwPower * 1e-12;
+      int numPclPerCore = (numElements + 63) / 64; // number of 64-bit popcount needed for a row
+      msRuntime = m_tR + m_pclNsDelay * numPclPerCore;
+      msRuntime *= bitsPerElement * numPass;
+      mjEnergy = m_eAP + mjEnergyPerPcl * numPclPerCore; // energy of one row read and row-wide popcount
+      mjEnergy *= bitsPerElement * numCore * numPass;
       // reduction for all regions
-      msRuntime += static_cast<double>(numRegions) / 3200000;
-      mjEnergy += 999999999.9; // todo
+      msRuntime += static_cast<double>(numCore) / 3200000;
       mjEnergy += m_pBCore * obj.getNumCoresUsed() + m_pBChip * m_numChipsPerRank * numRanks * msRuntime;
     } else {
       assert(0);

--- a/libpimeval/src/pimPerfEnergyModels.h
+++ b/libpimeval/src/pimPerfEnergyModels.h
@@ -64,6 +64,10 @@ private:
   double m_pBChip; // background power for each core in W
   double m_eGDL = 0.0000102; // CAS energy in mJ
 
+  // Popcount logc Params from DRAM-CAM paper
+  double m_pclNsDelay = 0.76; // 64-bit popcount logic ns delay, using LUT no pipeline design
+  double m_pclUwPower = 0.03; // 64-bit popcount logic uW power, using LUT no pipeline design
+
   // Following values are taken from fulcrum paper. 
   double m_fulcrumALUArithmeticEnergy = 0.0000000004992329586; // mJ
   double m_fulcrumALULogicalEnergy = 0.0000000001467846411; // mJ

--- a/libpimeval/src/pimPerfEnergyModels.h
+++ b/libpimeval/src/pimPerfEnergyModels.h
@@ -4,8 +4,8 @@
 // This file is licensed under the MIT License.
 // See the LICENSE file in the root of this repository for more details.
 
-#ifndef LAVA_PIM_PARAMS_PERF_H
-#define LAVA_PIM_PARAMS_PERF_H
+#ifndef LAVA_PIM_PERF_ENERGY_MODELS_H
+#define LAVA_PIM_PERF_ENERGY_MODELS_H
 
 #include "libpimeval.h"
 #include "pimParamsDram.h"

--- a/libpimeval/src/pimSim.cpp
+++ b/libpimeval/src/pimSim.cpp
@@ -95,9 +95,14 @@ void
 pimSim::uninit()
 {
   delete m_threadPool;
+  m_threadPool = nullptr;
   delete m_statsMgr;
+  m_statsMgr = nullptr;
   delete m_paramsDram;
+  m_paramsDram = nullptr;
   delete m_paramsPerf;
+  m_paramsPerf = nullptr;
+  m_initCalled = false;
 }
 
 //! @brief  Determine num threads and init thread pool
@@ -240,6 +245,7 @@ pimSim::deleteDevice()
   }
   delete m_device;
   m_device = nullptr;
+  uninit();
   return true;
 }
 

--- a/libpimeval/src/pimSim.cpp
+++ b/libpimeval/src/pimSim.cpp
@@ -7,7 +7,7 @@
 #include "pimSim.h"
 #include "pimCmd.h"
 #include "pimParamsDram.h"
-#include "pimParamsPerf.h"
+#include "pimPerfEnergyModels.h"
 #include "pimStats.h"
 #include "pimUtils.h"
 #include <cstdio>

--- a/libpimeval/src/pimSim.cpp
+++ b/libpimeval/src/pimSim.cpp
@@ -51,31 +51,35 @@ pimSim::pimSim()
 //! @brief  pimSim dtor
 pimSim::~pimSim()
 {
-  uninit(); 
+  uninit();
 }
 
 //! @brief  Initialize pimSim member classes from the config file
-void
+bool
 pimSim::init(const std::string& simConfigFileConetnt)
 {
   if (!m_initCalled) {
     if (!simConfigFileConetnt.empty()) {
       bool success = parseConfigFromFile(simConfigFileConetnt);
-      assert(success);
+      if (!success) {
+        return false;
+      }
 
       if (m_memConfigFileName.empty()) {
         std::string memConfigFileFullPath = m_configFilesPath + m_memConfigFileName;
         std::string fileContent;
         success = pimUtils::readFileContent(memConfigFileFullPath.c_str(), fileContent);
-        assert(success);
+        if (!success) {
+          return false;
+        }
         m_paramsDram = new pimParamsDram(fileContent);
       } else {
         m_paramsDram = new pimParamsDram();
       }
-      
+
       m_paramsPerf = new pimParamsPerf(m_paramsDram);
       m_statsMgr = new pimStatsMgr(m_paramsDram, m_paramsPerf);
-      m_initCalled = true; 
+      m_initCalled = true;
     } else {
       m_paramsDram = new pimParamsDram();
       m_paramsPerf = new pimParamsPerf(m_paramsDram);
@@ -83,10 +87,11 @@ pimSim::init(const std::string& simConfigFileConetnt)
       m_initCalled = true;
     }
   }
+  return true;
 }
 
-//! @brief  Uninitialize pimSim member claasses 
-void 
+//! @brief  Uninitialize pimSim member claasses
+void
 pimSim::uninit()
 {
   delete m_threadPool;
@@ -126,7 +131,11 @@ pimSim::createDevice(PimDeviceEnum deviceType, unsigned numRanks, unsigned numBa
     std::printf("PIM-Error: PIM device is already created\n");
     return false;
   }
-  init();
+  bool success = init();
+  if (!success) {
+    std::printf("PIM-Error: Init failed\n");
+    return false;
+  }
   m_device = new pimDevice();
   m_device->init(deviceType, numRanks, numBankPerRank, numSubarrayPerBank, numRows, numCols);
   if (!m_device->isValid()) {
@@ -150,14 +159,14 @@ pimSim::createDeviceFromConfig(PimDeviceEnum deviceType, const char* configFileN
   if (!configFileName) {
     std::printf("PIM-Info: Null PIM device config file name. Read the config file name from environment variables %s and %s\n", pimUtils::envVarPimEvalConfigPath, pimUtils::envVarPimEvalConfigSim);
 
-    // Read environment variable for the config file path  
+    // Read environment variable for the config file path
     std::string pimEvalConfigPath;
     if (!pimUtils::getEnvVar(pimUtils::envVarPimEvalConfigPath, pimEvalConfigPath)) {
       std::printf("PIM-Error: Could not read environment variable %s", pimUtils::envVarPimEvalConfigPath);
       return false;
     }
 
-    // Read environment variable for the simulation config file name 
+    // Read environment variable for the simulation config file name
     std::string pimEvalConfigSim;
     if (!pimUtils::getEnvVar(pimUtils::envVarPimEvalConfigSim, pimEvalConfigSim)) {
       std::printf("PIM-Error: Could not read environment variable %s", pimUtils::envVarPimEvalConfigSim);
@@ -175,11 +184,18 @@ pimSim::createDeviceFromConfig(PimDeviceEnum deviceType, const char* configFileN
 
   std::string fileContent;
   success = pimUtils::readFileContent(correctConfigFileName.c_str(), fileContent);
-  assert(success);
+  if (!success) {
+    std::printf("PIM-Error: Failed to read config file %s\n", correctConfigFileName.c_str());
+    return false;
+  }
 
   m_configFilesPath = pimUtils::getDirectoryPath(correctConfigFileName);
 
-  init(fileContent);
+  success = init(fileContent);
+  if (!success) {
+    std::printf("PIM-Error: Init failed\n");
+    return false;
+  }
   if (m_device) {
     std::printf("PIM-Error: PIM Device is already created\n");
     return false;
@@ -989,16 +1005,16 @@ pimSim::parseConfigFromFile(const std::string& simConfigFileConetnt) {
     }
   }
   try {
-    bool success = false; 
-    std::string temp; 
+    bool success = false;
+    std::string temp;
     temp = pimUtils::getOptionalParam(params, "max_num_threads", success);
     if (!success) {
       std::printf("PIM-Info: Maximum number of threads could not be located in PIMeval config file. Using maximum number of availale threads\n");
       m_numThreads = std::thread::hardware_concurrency();
     } else {
-      m_numThreads = std::stoi(temp); 
+      m_numThreads = std::stoi(temp);
     }
-    
+
     temp = pimUtils::getOptionalParam(params, "memory_config_file", success);
     if (!success) {
       std::printf("PIM-Info: PIM device params config file name could not be located in PIMeval config file. Using default values for memory config\n");

--- a/libpimeval/src/pimSim.h
+++ b/libpimeval/src/pimSim.h
@@ -133,7 +133,7 @@ private:
   ~pimSim();
   pimSim(const pimSim&) = delete;
   pimSim operator=(const pimSim&) = delete;
-  void init(const std::string& simConfigFileContent = "");
+  bool init(const std::string& simConfigFileContent = "");
   void uninit();
   bool parseConfigFromFile(const std::string& simConfigFileContent);
 

--- a/libpimeval/src/pimSim.h
+++ b/libpimeval/src/pimSim.h
@@ -10,7 +10,7 @@
 #include "libpimeval.h"
 #include "pimDevice.h"
 #include "pimParamsDram.h"
-#include "pimParamsPerf.h"
+#include "pimPerfEnergyModels.h"
 #include "pimStats.h"
 #include <vector>
 #include <cstdarg>

--- a/libpimeval/src/pimStats.h
+++ b/libpimeval/src/pimStats.h
@@ -8,7 +8,7 @@
 #define LAVA_PIM_STATS_H
 
 #include "pimParamsDram.h"
-#include "pimParamsPerf.h"
+#include "pimPerfEnergyModels.h"
 #include "libpimeval.h"
 #include <cstdint>
 #include <string>


### PR DESCRIPTION
Code changes:
- Rename pimParamsPerf.h/cc to pimPerfEnergyModels.h/cc
- Fix compilation warnings and code format issues in pimSim/pimDevice
- Fix incorrect uninit during device deletion
- Fix compilation issue of AES app in Makefile
- Update perf and energy model of reduction sum of bit-serial PIM
